### PR TITLE
chore: bump random dependency to allow 1.3.*

### DIFF
--- a/core/string-random.cabal
+++ b/core/string-random.cabal
@@ -34,7 +34,7 @@ library
       attoparsec    >=0.13.1  && <0.15
     , base          >=4.9     && <5
     , containers    >=0.5.7.1 && <0.8
-    , random        >=1.1     && <1.3
+    , random        >=1.1     && <1.4
     , text          >=1.2.2.1 && <2.2
     , transformers  >=0.5.2.0 && <0.7
 


### PR DESCRIPTION
See: https://github.com/commercialhaskell/stackage/issues/7648#issuecomment-2722583902