### PR TITLE
chore: fix CI by explicitly installing libpcre3-dev

### DIFF
--- a/.github/workflows/cabalv2.yml
+++ b/.github/workflows/cabalv2.yml
@@ -19,6 +19,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Install system dependencies
+      run: sudo apt-get update && sudo apt-get install -y libpcre3-dev
+
     - name: Set up GHC ${{ matrix.ghc-version }}
       uses: haskell-actions/setup@v2
       id: setup


### PR DESCRIPTION
GitHub Actions CI failed due to a missing system dependency required by `pcre-light`.

```
..snip..
Installing   hashable-1.5.0.0 (lib)
Completed    hashable-1.5.0.0 (lib)
Installing   prettyprinter-1.7.1 (lib)
Completed    prettyprinter-1.7.1 (lib)

Failed to build pcre-light-0.4.1.3. The failure occurred during the configure
step.
Build log (
/home/runner/.cabal/logs/ghc-9.12.2/pcre-light-0.4.1.3-c012dbeffba5c5302ad6a39b4245dae3f11d10e3809a568c4cd3c873c38c76cc.log
):
Configuring library for pcre-light-0.4.1.3...
Error: [Cabal-4345]
Error: [Cabal-7[125](https://github.com/hiratara/hs-string-random/actions/runs/14442432012/job/40495385597?pr=26#step:6:126)]
Failed to build pcre-light-0.4.1.3 (which is required by pcre-heavy-1.0.0.3). See the build log above for details.

Missing dependency on a foreign library:
* Missing (or bad) C library: pcre

Error: Process completed with exit code 1.
```